### PR TITLE
이슈 템플릿 업데이트

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml
+++ b/.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml
@@ -13,6 +13,14 @@ body:
       **이슈 하나당 챌린지 하나씩 인증 가능합니다**
 
 - type: dropdown
+  id: title
+  attributes:
+    label: '클라우드 스킬 챌린지'
+    options:
+      - '클라우드 스킬 챌린지'
+    default: 0
+
+- type: dropdown
   id: challenge_code
   attributes:
     label: '챌린지 코드'

--- a/.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml
+++ b/.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml
@@ -8,6 +8,14 @@ body:
     value: |
       **👆👆👆 상단의 제목에 팀 이름을 반드시 적어 주세요 👆👆👆**
 
+- type: dropdown
+  id: title
+  attributes:
+    label: '팀 주제 제출'
+    options:
+      - '팀 주제 제출'
+    default: 0
+
 - type: input
   id: team_name
   attributes:

--- a/.github/ISSUE_TEMPLATE/03-TEAM-APP.yml
+++ b/.github/ISSUE_TEMPLATE/03-TEAM-APP.yml
@@ -8,6 +8,14 @@ body:
     value: |
       **👆👆👆 상단의 제목에 팀 이름을 반드시 적어 주세요 👆👆👆**
 
+- type: dropdown
+  id: title
+  attributes:
+    label: '팀 앱 제출'
+    options:
+      - '팀 앱 제출'
+    default: 0
+
 - type: input
   id: team_name
   attributes:

--- a/.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml
+++ b/.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml
@@ -8,6 +8,14 @@ body:
     value: |
       **👆👆👆 상단의 제목에 팀 이름을 반드시 적어 주세요 👆👆👆**
 
+- type: dropdown
+  id: title
+  attributes:
+    label: '팀 발표자료 제출'
+    options:
+      - '팀 발표자료 제출'
+    default: 0
+
 - type: input
   id: team_name
   attributes:


### PR DESCRIPTION
This pull request introduces changes to four issue templates in the `.github/ISSUE_TEMPLATE/` directory. The changes involve the addition of a new dropdown field labeled `title` in each template. The new dropdown field has been added to provide specific labels for different types of issues, which could help in better categorizing and sorting issues.

Changes made:

* [`.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml`](diffhunk://#diff-967e5fe14da0ba269676462673b9d419cb511eb242d13228e726186ca9bccd55R15-R22): Added a dropdown field with the label '클라우드 스킬 챌린지' to the issue template.
* [`.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml`](diffhunk://#diff-53fdd020b5d5018664702b718d00c3a078e7f89ccfd6054eff9abdb545f64f89R11-R18): Added a dropdown field with the label '팀 주제 제출' to the issue template.
* [`.github/ISSUE_TEMPLATE/03-TEAM-APP.yml`](diffhunk://#diff-f4ecbfb58dee71e54ee1ef3940660d3067966927703704a0e19f1e3ae36df0c9R11-R18): Added a dropdown field with the label '팀 앱 제출' to the issue template.
* [`.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml`](diffhunk://#diff-eff53b2b0c395a70ebf587355b08846b8ff00a9244b7f8c02ac39797936448b6R11-R18): Added a dropdown field with the label '팀 발표자료 제출' to the issue template.