### PR TITLE
이슈 템플릿 업데이트

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml
+++ b/.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml
@@ -15,7 +15,7 @@ body:
 - type: dropdown
   id: title
   attributes:
-    label: '클라우드 스킬 챌린지'
+    label: '제목'
     options:
       - '클라우드 스킬 챌린지'
     default: 0

--- a/.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml
+++ b/.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml
@@ -11,7 +11,7 @@ body:
 - type: dropdown
   id: title
   attributes:
-    label: '팀 주제 제출'
+    label: '제목'
     options:
       - '팀 주제 제출'
     default: 0

--- a/.github/ISSUE_TEMPLATE/03-TEAM-APP.yml
+++ b/.github/ISSUE_TEMPLATE/03-TEAM-APP.yml
@@ -11,7 +11,7 @@ body:
 - type: dropdown
   id: title
   attributes:
-    label: '팀 앱 제출'
+    label: '제목'
     options:
       - '팀 앱 제출'
     default: 0

--- a/.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml
+++ b/.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml
@@ -11,7 +11,7 @@ body:
 - type: dropdown
   id: title
   attributes:
-    label: '팀 발표자료 제출'
+    label: '제목'
     options:
       - '팀 발표자료 제출'
     default: 0


### PR DESCRIPTION
This pull request includes changes to the issue templates in the `.github/ISSUE_TEMPLATE/` directory. The main change is the modification of the `label` attribute in the `title` dropdown for each template. Specifically, the labels have been changed to '제목' in all the templates.

Here are the key changes:

* [`.github/ISSUE_TEMPLATE/01-CSC-COMPLETION.yml`](diffhunk://#diff-967e5fe14da0ba269676462673b9d419cb511eb242d13228e726186ca9bccd55L18-R18): The `label` attribute in the `title` dropdown has been changed from '클라우드 스킬 챌린지' to '제목'.
* [`.github/ISSUE_TEMPLATE/02-TEAM-TOPIC.yml`](diffhunk://#diff-53fdd020b5d5018664702b718d00c3a078e7f89ccfd6054eff9abdb545f64f89L14-R14): The `label` attribute in the `title` dropdown has been changed from '팀 주제 제출' to '제목'.
* [`.github/ISSUE_TEMPLATE/03-TEAM-APP.yml`](diffhunk://#diff-f4ecbfb58dee71e54ee1ef3940660d3067966927703704a0e19f1e3ae36df0c9L14-R14): The `label` attribute in the `title` dropdown has been changed from '팀 앱 제출' to '제목'.
* [`.github/ISSUE_TEMPLATE/04-TEAM-PITCH.yml`](diffhunk://#diff-eff53b2b0c395a70ebf587355b08846b8ff00a9244b7f8c02ac39797936448b6L14-R14): The `label` attribute in the `title` dropdown has been changed from '팀 발표자료 제출' to '제목'.